### PR TITLE
Add custom hide duration as an attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ In cases where the project is not able to process JS assets, there are pre-proce
 ```html
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@/dist/auro-classic/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-toast@3.1.3/dist/auro-toast__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-toast@3.2.0/dist/auro-toast__bundled.js" type="module"></script>
 ```
 
 <!-- AURO-GENERATED-CONTENT:END -->

--- a/apiExamples/timeTilHide.html
+++ b/apiExamples/timeTilHide.html
@@ -1,0 +1,6 @@
+<auro-button id="timeTilHideToastBtn">
+  Show default notification
+</auro-button>
+<auro-toast timeTilHide="1000" style="display: block; margin: 0.5rem 0;" id="timeTilHideToast">
+  Default notification with no error type
+</auro-toast>

--- a/apiExamples/timeTilHide.js
+++ b/apiExamples/timeTilHide.js
@@ -1,0 +1,12 @@
+/* eslint-disable jsdoc/require-jsdoc */
+
+export function initTimeTilHideExample() {
+  const btn = document.querySelector('#timeTilHideToastBtn');
+  const toast = document.querySelector('#timeTilHideToast');
+
+  btn.addEventListener('click', () => {
+    if (!toast.hasAttribute('visible')) {
+      toast.setAttribute('visible', true);
+    }
+  });
+}

--- a/demo/api.js
+++ b/demo/api.js
@@ -1,6 +1,7 @@
 import { initVisibleExample } from "../apiExamples/visible";
 import { initVariantToastsExample } from "../apiExamples/variant";
 import { initNoIconExample } from "../apiExamples/noIcon";
+import { initTimeTilHideExample } from "../apiExamples/timeTilHide";
 
 import '../index.js';
 /* eslint-disable jsdoc/require-jsdoc, no-magic-numbers, no-param-reassign */
@@ -13,6 +14,7 @@ export function initExamples(initCount) {
     initVisibleExample();
     initVariantToastsExample();
     initNoIconExample();
+    initTimeTilHideExample();
   } catch (err) {
     if (initCount <= 20) {
       // setTimeout handles issue where content is sometimes loaded after the functions get called

--- a/demo/api.md
+++ b/demo/api.md
@@ -11,6 +11,7 @@ The auro-toast element provides users a way to display short, temporary messages
 |-------------------|-------------------|-----------|--------------------------------------------------|
 | [disableAutoHide](#disableAutoHide) | `disableAutoHide` | `Boolean` | Prevents the toast from auto-hiding on the default time. |
 | [noIcon](#noIcon)          | `noIcon`          | `Boolean` | Removes icon from the toast UI                   |
+| [timeTilHide](#timeTilHide)     | `timeTilHide`     | `Number`  | Sets the time in milliseconds until the toast hides. |
 | [variant](#variant)         | `variant`         | `String`  | Component will render visually based on which variant value is set; currently supports `error`, `success`, `custom` |
 | [visible](#visible)         | `visible`         | `Boolean` | Sets state of toast to visible                   |
 
@@ -163,6 +164,50 @@ Using the `noIcon` attribute will set no icon to be visible in the notification.
 ```html
 <auro-button id="noIconBtn"> Show toast with no icon </auro-button>
 <auro-toast id="noIcon" noIcon style="display: block; margin: 0.5rem 0;"> Default toast </auro-toast>
+```
+<!-- AURO-GENERATED-CONTENT:END -->
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/showToast.js) -->
+<!-- The below code snippet is automatically added from ./../apiExamples/showToast.js -->
+
+```js
+export function showToast(toastID) {
+  const toast = document.querySelector(toastID);
+
+  if (!toast.hasAttribute('visible')) {
+    toast.setAttribute('visible', true);
+  }
+};
+```
+<!-- AURO-GENERATED-CONTENT:END -->
+</auro-accordion>
+
+#### timeTilHide
+
+Using the `timeTilHide` attribute will set a timer in milliseconds for how long the notification will be visible before it automatically hides. The default is `5000` milliseconds.
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/timeTilHide.html) -->
+  <!-- The below content is automatically added from ./../apiExamples/timeTilHide.html -->
+  <auro-button id="timeTilHideToastBtn">
+    Show default notification
+  </auro-button>
+  <auro-toast timeTilHide="1000" style="display: block; margin: 0.5rem 0;" id="timeTilHideToast">
+    Default notification with no error type
+  </auro-toast>
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/timeTilHide.html) -->
+<!-- The below code snippet is automatically added from ./../apiExamples/timeTilHide.html -->
+
+```html
+<auro-button id="timeTilHideToastBtn">
+  Show default notification
+</auro-button>
+<auro-toast timeTilHide="1000" style="display: block; margin: 0.5rem 0;" id="timeTilHideToast">
+  Default notification with no error type
+</auro-toast>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/showToast.js) -->

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,7 @@ The auro-toast element provides users a way to display short, temporary messages
 |-------------------|-------------------|-----------|--------------------------------------------------|
 | `disableAutoHide` | `disableAutoHide` | `Boolean` | Prevents the toast from auto-hiding on the default time. |
 | `noIcon`          | `noIcon`          | `Boolean` | Removes icon from the toast UI                   |
+| `timeTilHide`     | `timeTilHide`     | `Number`  | Sets the time in milliseconds until the toast hides. |
 | `variant`         | `variant`         | `String`  | Component will render visually based on which variant value is set; currently supports `error`, `success`, `custom` |
 | `visible`         | `visible`         | `Boolean` | Sets state of toast to visible                   |
 

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -51,6 +51,7 @@ Using the `noIcon` attribute will set no icon to be visible in the notification.
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/noIcon.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
+
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
 
@@ -60,6 +61,25 @@ Using the `noIcon` attribute will set no icon to be visible in the notification.
 <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/showToast.js) -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
+</auro-accordion>
+
+#### timeTilHide
+
+Using the `timeTilHide` attribute will set a timer in milliseconds for how long the notification will be visible before it automatically hides. The default is `5000` milliseconds.
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/timeTilHide.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/timeTilHide.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/showToast.js) -->
+<!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-toast",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-toast",
-      "version": "3.1.2",
+      "version": "3.2.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "================================================================================"
   ],
   "name": "@aurodesignsystem/auro-toast",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "description": "auro-toast HTML custom element",
   "repository": {
     "type": "git",

--- a/src/auro-toast.js
+++ b/src/auro-toast.js
@@ -41,7 +41,7 @@ const FADE_OUT_DURATION = 300;
  * @attr {String} variant - Component will render visually based on which variant value is set; currently supports `error`, `success`, `custom`
  * @attr {Boolean} noIcon - Removes icon from the toast UI
  * @attr {Boolean} disableAutoHide - Prevents the toast from auto-hiding on the default time.
- * @attr {Boolean} timeTilFadeOut - Sets the time in seconds until the toast fades out.
+ * @attr {Number} timeTilHide - Sets the time in seconds until the toast hides.
  * @csspart type-icon - Apply css to the toast type icon
  * @csspart close-button - Apply css to the toast close button
  * @fires onToastClose - Notifies that the toast has been closed
@@ -143,6 +143,7 @@ export class AuroToast extends LitElement {
       },
       timeTilHide: {
         type: Number,
+        reflect: true
       }
     };
   }

--- a/src/auro-toast.js
+++ b/src/auro-toast.js
@@ -29,7 +29,8 @@ import buttonVersion from './buttonVersion.js';
 import { AuroIcon } from '@aurodesignsystem/auro-icon/src/auro-icon.js';
 import iconVersion from './iconVersion.js';
 
-const TIME_TIL_FADE_OUT = 5000;
+const DEFAULT_TIME_TIL_FADE_OUT = 5000;
+const MS_IN_SECOND = 1000;
 const FADE_OUT_DURATION = 300;
 
 // See https://git.io/JJ6SJ for "How to document your components using JSDoc"
@@ -40,6 +41,7 @@ const FADE_OUT_DURATION = 300;
  * @attr {String} variant - Component will render visually based on which variant value is set; currently supports `error`, `success`, `custom`
  * @attr {Boolean} noIcon - Removes icon from the toast UI
  * @attr {Boolean} disableAutoHide - Prevents the toast from auto-hiding on the default time.
+ * @attr {Boolean} timeTilFadeOut - Sets the time in seconds until the toast fades out.
  * @csspart type-icon - Apply css to the toast type icon
  * @csspart close-button - Apply css to the toast close button
  * @fires onToastClose - Notifies that the toast has been closed
@@ -138,6 +140,9 @@ export class AuroToast extends LitElement {
       disableAutoHide: {
         type: Boolean,
         reflect: true
+      },
+      timeTilHide: {
+        type: Number,
       }
     };
   }
@@ -257,11 +262,12 @@ export class AuroToast extends LitElement {
     if (changedProperties.has('variant')) {
       clearTimeout(this.fadeOutTimer);
     }
+
     // do not auto dismiss for error toasts or if disableAutoHide is set
     if (this.visible && !this.disableAutoHide && this.variant !== 'error') {
       this.fadeOutTimer = setTimeout(() => {
         this.fadeOutToast();
-      }, TIME_TIL_FADE_OUT);
+      }, this.timeTilHide * MS_IN_SECOND || DEFAULT_TIME_TIL_FADE_OUT);
     }
   }
 

--- a/src/auro-toast.js
+++ b/src/auro-toast.js
@@ -30,7 +30,6 @@ import { AuroIcon } from '@aurodesignsystem/auro-icon/src/auro-icon.js';
 import iconVersion from './iconVersion.js';
 
 const DEFAULT_TIME_TIL_FADE_OUT = 5000;
-const MS_IN_SECOND = 1000;
 const FADE_OUT_DURATION = 300;
 
 // See https://git.io/JJ6SJ for "How to document your components using JSDoc"
@@ -41,7 +40,7 @@ const FADE_OUT_DURATION = 300;
  * @attr {String} variant - Component will render visually based on which variant value is set; currently supports `error`, `success`, `custom`
  * @attr {Boolean} noIcon - Removes icon from the toast UI
  * @attr {Boolean} disableAutoHide - Prevents the toast from auto-hiding on the default time.
- * @attr {Number} timeTilHide - Sets the time in seconds until the toast hides.
+ * @attr {Number} timeTilHide - Sets the time in milliseconds until the toast hides.
  * @csspart type-icon - Apply css to the toast type icon
  * @csspart close-button - Apply css to the toast close button
  * @fires onToastClose - Notifies that the toast has been closed
@@ -268,7 +267,7 @@ export class AuroToast extends LitElement {
     if (this.visible && !this.disableAutoHide && this.variant !== 'error') {
       this.fadeOutTimer = setTimeout(() => {
         this.fadeOutToast();
-      }, this.timeTilHide * MS_IN_SECOND || DEFAULT_TIME_TIL_FADE_OUT);
+      }, this.timeTilHide || DEFAULT_TIME_TIL_FADE_OUT);
     }
   }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Enable custom auto-dismiss timing on auro-toast by introducing a timeTilHide attribute with a default 5-second fallback, and update related constants and documentation.

New Features:
- Allow configuring toast auto-hide duration via a new timeTilHide attribute (in seconds)

Enhancements:
- Rename TIME_TIL_FADE_OUT to DEFAULT_TIME_TIL_FADE_OUT
- Add MS_IN_SECOND constant for unit conversion in timeout calculation

Build:
- Bump package version to 3.2.0

Documentation:
- Document the new timeTilHide attribute in the component JSDoc