### PR TITLE
fix: center align icon when text is multi-line

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -35,7 +35,7 @@
     display: flex;
     width: 100%;
     flex-direction: row;
-    align-items: baseline;
+    align-items: center;
     gap: var(--ds-size-200, vac.$ds-size-200);
   }
 
@@ -58,8 +58,3 @@
   }
 }
 
-:host([visible]:not([noIcon])) {
-  .closeButton {
-    margin-top: calc(var(--ds-size-25, vac.$ds-size-25) + calc(var(--ds-size-25, vac.$ds-size-25) / 2));
-  }
-}


### PR DESCRIPTION
When a Toast features multiple lines of copy, the close icon is misaligned:

<img width="336" height="370" alt="Image" src="https://github.com/user-attachments/assets/306d3850-5e0a-4fb8-b7ba-abe356a0da89" />

## Expectation

The icon should be middle-aligned:

<img width="339" height="279" alt="Image" src="https://github.com/user-attachments/assets/b9197ebe-b2c3-4775-a12c-4fcb8f6c30df" />

## Resources

Relevant Figma:

https://www.figma.com/design/VpUz89Ov6ImBpY5YvzYbZW/Auro-toolkit?node-id=7943-1362&p=f&m=dev

## Testing

Design review completed.

Demo links:

- https://auro-toast-pr66-5.surge.sh
- https://auro-toast-pr66-5.surge.sh/api

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
