### PR TITLE
fix: top align icon and x button in multi-line

### DIFF
--- a/src/auro-toast.js
+++ b/src/auro-toast.js
@@ -266,6 +266,7 @@ export class AuroToast extends LitElement {
 
     // do not auto dismiss for error toasts or if disableAutoHide is set
     if (this.visible && !this.disableAutoHide && this.variant !== "error") {
+      clearTimeout(this.fadeOutTimer);
       this.fadeOutTimer = setTimeout(() => {
         this.fadeOutToast();
       }, this.timeTilHide || DEFAULT_TIME_TIL_FADE_OUT);
@@ -303,7 +304,7 @@ export class AuroToast extends LitElement {
           this.noIcon
             ? undefined
             : html`
-          <${this.iconTag} customColor customSvg class="typeIcon" part="type-icon">
+          <${this.iconTag} customColor customSvg class="typeIcon body-default" part="type-icon">
             ${this.variant === "custom" ? undefined : html`${this.getVariantIcon()}`}
           </${this.iconTag}>
         `
@@ -313,7 +314,7 @@ export class AuroToast extends LitElement {
           variant="flat"
           shape="circle"
           size="xs"
-          appearance=${this.getAttribute("variant") !== "error" && this.getAttribute("variant") !== "success" ? "inverse" : this.appearance}
+          appearance=${this.variant !== "error" && this.variant !== "success" ? "inverse" : this.appearance}
           @click="${this.clickToClose}"
           part="close-button"
           class="closeButton">

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -31,6 +31,7 @@
     display: flex;
     width: 100%;
     flex-direction: row;
+    align-items: flex-start;
     gap: var(--ds-size-200, vac.$ds-size-200);
   }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

- icon and x button should be aligned on the first line
- bind `this.variant`to x button's appearance instead of getAttribute('variant')
- cancel timeout before setting a new one

<img width="317" height="293" alt="image" src="https://github.com/user-attachments/assets/6ed2ba0a-2f78-4bfb-baf6-177ceca6817a" />

<img width="333" height="328" alt="image" src="https://github.com/user-attachments/assets/4c3e145d-2bfb-49e9-9642-b80a84ba2b00" />


Closes #71 #91 #69

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve auro-toast component alignment, appearance binding, and timeout handling.

Bug Fixes:
- Cancel existing timeout before starting a new auto-dismiss timer
- Bind close button appearance to the component’s variant property instead of the attribute

Enhancements:
- Add top alignment for icons and close button in multi-line toasts
- Apply default body style class to variant icons for consistent styling

## Summary by Sourcery

Improve AuroToast component by top-aligning icons and close button in multi-line toasts, binding close button appearance to the variant property, and resetting the auto-dismiss timer correctly.

Bug Fixes:
- Clear existing fade-out timer before starting a new auto-dismiss timeout
- Bind close button appearance to the component’s variant property instead of reading the attribute

Enhancements:
- Top-align icons and close button in multi-line toasts via CSS
- Apply a default body style class to variant icons for consistent styling