### PR TITLE
RC 2025-10-29

### DIFF
--- a/src/auro-toast.js
+++ b/src/auro-toast.js
@@ -266,6 +266,7 @@ export class AuroToast extends LitElement {
 
     // do not auto dismiss for error toasts or if disableAutoHide is set
     if (this.visible && !this.disableAutoHide && this.variant !== "error") {
+      clearTimeout(this.fadeOutTimer);
       this.fadeOutTimer = setTimeout(() => {
         this.fadeOutToast();
       }, this.timeTilHide || DEFAULT_TIME_TIL_FADE_OUT);
@@ -303,7 +304,7 @@ export class AuroToast extends LitElement {
           this.noIcon
             ? undefined
             : html`
-          <${this.iconTag} customColor customSvg class="typeIcon" part="type-icon">
+          <${this.iconTag} customColor customSvg class="typeIcon body-default" part="type-icon">
             ${this.variant === "custom" ? undefined : html`${this.getVariantIcon()}`}
           </${this.iconTag}>
         `
@@ -313,7 +314,7 @@ export class AuroToast extends LitElement {
           variant="flat"
           shape="circle"
           size="xs"
-          appearance=${this.getAttribute("variant") !== "error" && this.getAttribute("variant") !== "success" ? "inverse" : this.appearance}
+          appearance=${this.variant !== "error" && this.variant !== "success" ? "inverse" : this.appearance}
           @click="${this.clickToClose}"
           part="close-button"
           class="closeButton">

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -31,6 +31,7 @@
     display: flex;
     width: 100%;
     flex-direction: row;
+    align-items: flex-start;
     gap: var(--ds-size-200, vac.$ds-size-200);
   }
 


### PR DESCRIPTION
## RC Summary 

- fix ac4e62d | 2025-10-27 | Eunsun Mota
fix: top align icon and x button in multi-line

## Summary by Sourcery

Fix toast auto-dismiss timer reset and top-align icon and close button in multiline toasts.

Bug Fixes:
- Clear existing fadeOutTimer before setting a new auto-dismiss timeout to prevent multiple timers
- Add body-default class to the toast icon and use the variant property for close-button appearance
- Align icon and close button to the top in multiline toasts by adding align-items: flex-start in CSS