### PR TITLE
fix: move toast's padding to inside from `:host` #100

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -10,12 +10,10 @@
 
 // container styles - defines the look of the outer custom component
 :host([visible]) {
-  display: inline-flex;
+  display: inline-block;
   min-width: 100%;
-  padding: var(--ds-size-200, vac.$ds-size-200) var(--ds-size-150, vac.$ds-size-150);
   border-radius: var(--ds-size-100, vac.$ds-size-100);
   box-shadow: var(--ds-elevation-200, vac.$ds-elevation-200);
-  gap: var(--ds-size-200, vac.$ds-size-200);
   pointer-events: auto;
 
   @media (#{vac.$ds-grid-breakpoint-sm} <= width < #{vac.$ds-grid-breakpoint-lg}) {
@@ -29,9 +27,9 @@
 
   .toastContainer {
     display: flex;
-    width: 100%;
     flex-direction: row;
     align-items: flex-start;
+    padding: var(--ds-size-200, vac.$ds-size-200) var(--ds-size-150, vac.$ds-size-150);
     gap: var(--ds-size-200, vac.$ds-size-200);
   }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

move padding from :host to a wrapper under shadowRoot, so that the host wont spill over

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Enhancements:
- Move toast padding and gap styles from the host element to an inner wrapper to prevent overflow