### PR TITLE
ci: forward ADO_TOKEN to the RC reusable workflow

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -10,3 +10,4 @@ jobs:
     uses: AlaskaAirlines/auro-actions/.github/workflows/release-candidate.yml@main
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      ADO_TOKEN: ${{ secrets.ADO_TOKEN }}


### PR DESCRIPTION
Forward the repo-level ADO_TOKEN secret to the reusable RC workflow so `auro rc-workflow` can resolve the Azure DevOps Release ticket. The reusable workflow declares ADO_TOKEN as required; without this the RC Workflow fails before it starts. Opened automatically by admin-scripts/update-repo-secret-ADO_TOKEN.sh.

## Summary by Sourcery

Forward the Azure DevOps token to the release-candidate workflow to prevent it from failing before execution.

Bug Fixes:
- Ensure the release-candidate reusable workflow receives the required Azure DevOps token so it can resolve Release tickets successfully.

CI:
- Pass the repository-level ADO_TOKEN secret to the release-candidate workflow.